### PR TITLE
Update stage push workflow and makefile

### DIFF
--- a/.github/workflows/stage_ecr_push.yml
+++ b/.github/workflows/stage_ecr_push.yml
@@ -1,0 +1,21 @@
+# Borrowed heavily from mario
+name: Stage
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy staging build
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.DSS_DEPLOY_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DSS_DEPLOY_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: make dist
+      - name: Push image
+        run: make publish

--- a/.github/workflows/stage_ecr_push.yml
+++ b/.github/workflows/stage_ecr_push.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   deploy:
     name: Deploy staging build
-    needs: test
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-east-1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install dist update
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
-
+ECR_REGISTRY=672626379771.dkr.ecr.us-east-1.amazonaws.com
 
 help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
@@ -11,8 +11,15 @@ install:
 	pipenv install --dev
 
 dist: ## Build docker container
-	docker build -t submitter .
+	docker build -t $(ECR_REGISTRY)/dspacediscoveryservice-stage:latest \
+		-t $(ECR_REGISTRY)/dspacediscoveryservice-stage:`git describe --always` \
+		-t submitter:latest .	
 
 update: install ## Update all Python dependencies
 	pipenv clean
 	pipenv update --dev
+
+publish: dist ## Build, tag and push
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY)
+	docker push $(ECR_REGISTRY)/dspacediscoveryservice-stage:latest
+	docker push $(ECR_REGISTRY)/dspacediscoveryservice-stage:`git describe --always`


### PR DESCRIPTION
# Why these changes are being introduced:
These changes introduce a github action to publish a docker image when a push to main happens.
That push is currently to a stage ecr repo.

# How this addresses that need:
* Create a new workflow, copied heavily from mario
* Update the makefile to perform the build, tag it properly, and upload it to ECR

# Side effects of this change:
# None

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ETD-401

#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- [NA] All new ENV is documented in README
- [NA] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)

#### How can a reviewer manually see the effects of these changes?
Because this action only happens on pushes to main, we wont know for sure whether this works until merged into main. 
The makefile can be tested separately however, and if a user possesses aws credentials that are valid for the task, they should see the docker image pushed to the ECR registry with a `make publish` 

Note: 
These changes relate to infrastructure changes here - https://github.com/MITLibraries/mitlib-terraform/tree/dspace-submission-service
Because these changes have not been pushed to production yet, changes may need to occur with the make and actions as we refine our deployment and infrastructure.  

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
