### PR TITLE
Update makefile with runtask for stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ publish: dist ## Build, tag and push
 	docker push $(ECR_REGISTRY)/dspacesubmissionservice-stage:latest
 	docker push $(ECR_REGISTRY)/dspacesubmissionservice-stage:`git describe --always`
 
-run-stage: 
+run-stage:  ## Runs the task in stage - see readme for more info
 	aws ecs run-task --cluster dspacesubmissionservice-stage --task-definition dspacesubmissionservice-stage --network-configuration "awsvpcConfiguration={subnets=[subnet-0744a5c9beeb49a20],securityGroups=[sg-06b90b77a06e5870a],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1
 
 lint: bandit black flake8 isort ## Runs all linters

--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ docker run submitter:latest --
 ```
 
 note: the application requires being run in an environment with Roles based access to the AWS resources. in addition, the environment must have WORKSPACE and SSM_PATH variables set according to stage and prod conventions.
+
+## Makefile Info 
+### Run-Stage
+Run-stage is outputted by the terraform used to create the infrastructure and copy/pasted here for convenience.
+Calling run-stage will execute the latest version of the container in the stage environment using the MITVPC.


### PR DESCRIPTION
This PR updates the makefile with a new command - "run-stage"
Run-stage is outputted by the terraform used to create the infrastructure and copy/pasted here for convenience.
Calling run-stage will execute the latest version of the container in the stage environment using the MITVPC.

#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- [NA] All new ENV is documented in README
- [NA] All new ENV has been added to staging and production environments
- [NA] All related Jira tickets are linked in commit message(s)

#### How can a reviewer manually see the effects of these changes?

No changes to app. 


#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
