### PR TITLE
Verify message sent to result queue

### DIFF
--- a/submitter/errors.py
+++ b/submitter/errors.py
@@ -131,6 +131,36 @@ class DSpaceTimeoutError(Exception):
         )
 
 
+class SQSMessageSendError(Exception):
+    """Exception raised when a message sent to an SQS result queue cannot be verified.
+
+    Args:
+        message_attributes: The attributes of the message that was not successfully sent
+        message_body: The body of the message that was not succesfully sent
+        result_queue: The name of the result queue that the message was sent to
+        submit_message_id: The SQS ID of the corresponding submit message
+
+    Attributes:
+        message(str): Explanation of the error
+    """
+
+    def __init__(
+        self,
+        message_attributes: dict,
+        message_body: dict,
+        result_queue: str,
+        submit_message_id: str,
+    ):
+        self.message = (
+            f"Message was not successfully sent to result queue '{result_queue}', "
+            "aborting DSpace Submission Service processing until this can be "
+            "investigated. NOTE: The submit message is likely still in the submission "
+            "queue and may need to be manually deleted before processing "
+            f"resumes. Submit message ID: {submit_message_id}. Result message "
+            f"attributes: {message_attributes}. Result message body: {message_body}"
+        )
+
+
 class SubmitMessageInvalidResultQueueError(Exception):
     """Exception raised due to an invalid result queue name in a submission message.
 


### PR DESCRIPTION
#### Why these changes are being introduced:
We want to confirm that a message has been successfully sent to a result queue before deleting its original submission message from the submit queue.

#### How this addresses that need:
* Adds a function to verify the message was successfully written to a result queue, with corresponding test
* Calls the verify message during processing and raises an error if the result message can't be verified

#### Includes new or updated dependencies?
NO

#### Changes expectations for external applications?
NO

#### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)

#### How can a reviewer manually see the effects of these changes?
Unfortunately it's really hard to do this because you'd have to simulate SQS returning a failed message write response (there isn't a test for raising the new error for the same reason, moto doesn't allow changing the SQS response value and botocore's implementation method makes it difficult to mock). 

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
