### PR TITLE
Update makefile with prod infrastructure commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,19 @@ publish: dist ## Build, tag and push
 	docker push $(ECR_REGISTRY)/dspacesubmissionservice-stage:latest
 	docker push $(ECR_REGISTRY)/dspacesubmissionservice-stage:`git describe --always`
 
+promote: ## Promote the current staging build to production
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY)
+	docker pull $(ECR_REGISTRY)/dspacesubmissionservice-stage:latest
+	docker tag $(ECR_REGISTRY)/dspacesubmissionservice-stage:latest $(ECR_REGISTRY)/dspacesubmissionservice-prod:latest
+	docker tag $(ECR_REGISTRY)/dspacesubmissionservice-stage:latest $(ECR_REGISTRY)/dspacesubmissionservice-prod:$(DATETIME)
+	docker push $(ECR_REGISTRY)/dspacesubmissionservice-prod:latest
+	docker push $(ECR_REGISTRY)/dspacesubmissionservice-prod:$(DATETIME)
+
 run-stage:  ## Runs the task in stage - see readme for more info
 	aws ecs run-task --cluster dspacesubmissionservice-stage --task-definition dspacesubmissionservice-stage --network-configuration "awsvpcConfiguration={subnets=[subnet-0744a5c9beeb49a20],securityGroups=[sg-06b90b77a06e5870a],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1
+
+run-prod: ##Runs the task in prod - see readme for more info
+	aws ecs run-task --cluster dspacesubmissionservice-prod --task-definition dspacesubmissionservice-prod --network-configuration "awsvpcConfiguration={subnets=[subnet-0744a5c9beeb49a20],securityGroups=[sg-0b29d571e70c05101],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1
 
 lint: bandit black flake8 isort ## Runs all linters
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ docker run submitter:latest --
 note: the application requires being run in an environment with Roles based access to the AWS resources. in addition, the environment must have WORKSPACE and SSM_PATH variables set according to stage and prod conventions.
 
 ## Makefile Info
-### Run-Stage
+### run-stage
 Run-stage is outputted by the terraform used to create the infrastructure and copy/pasted here for convenience.
 Calling run-stage will execute the latest version of the container in the stage environment using the MITVPC.
+
+### run-prod 
+run-prod is just like run-stage, except it runs the prod infrastructure version


### PR DESCRIPTION
# Subject
Add two new prod infrastructure makefile commands

# Why these changes are being introduced:
These changes are needed to include makefile commands for prod infrastructure to promote the stage image from stage to prod, and run the prod infrastructure.

# How this addresses that need:
Add the two commands, which are pretty much copy/paste from mario, and copy/paste from the output of the infrastructure deploy

# Side effects of this change:
None

# Relevant ticket(s):
https://mitlibraries.atlassian.net/browse/ETD-520

#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- [NA] All new ENV is documented in README
- [NA] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)

#### How can a reviewer manually see the effects of these changes?

The reviewer can attempt to run these commands if they wish.  I tested a promotion(`make promote`) from stage to prod which was successful.  Be careful to use the correct AWS_profile.  
I did not test the run command in prod because it would fail until all the SSM values are in place, but i do not expect there to be any issue there once everything is in place since its copied from the output of the infrastructure deploy.  

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
