### PR TITLE
Adds method to load sample result messages

### DIFF
--- a/submitter/cli.py
+++ b/submitter/cli.py
@@ -3,7 +3,10 @@ import logging
 import click
 
 from submitter import CONFIG
-from submitter.message import generate_submission_messages_from_file
+from submitter.message import (
+    generate_result_messages_from_file,
+    generate_submission_messages_from_file,
+)
 from submitter.s3 import check_s3_permissions
 from submitter.sqs import (
     check_read_permissions,
@@ -53,7 +56,7 @@ def start(queue, wait):
     default="tests/fixtures/completely-fake-data.json",
     help="Path to json file of sample messages to load",
 )
-def load_sample_data(input_queue, output_queue, filepath):
+def load_sample_input_data(input_queue, output_queue, filepath):
     logger.info(f"Loading sample data from file '{filepath}' into queue {input_queue}")
     count = 0
     messages = generate_submission_messages_from_file(filepath, output_queue)
@@ -61,6 +64,29 @@ def load_sample_data(input_queue, output_queue, filepath):
         write_message_to_queue(message[0], message[1], input_queue)
         count += 1
     logger.info(f"{count} messages loaded into queue {input_queue}")
+
+
+@main.command()
+@click.option(
+    "-o",
+    "--output-queue",
+    help="Name of queue to load sample messages to",
+)
+@click.option(
+    "-f",
+    "--filepath",
+    type=click.Path(exists=True),
+    default="tests/fixtures/completely-fake-data.json",
+    help="Path to json file of sample messages to load",
+)
+def load_sample_output_data(output_queue, filepath):
+    logger.info(f"Loading sample data from file '{filepath}' into queue {output_queue}")
+    count = 0
+    messages = generate_result_messages_from_file(filepath, output_queue)
+    for message in messages:
+        write_message_to_queue(message[0], message[1], output_queue)
+        count += 1
+    logger.info(f"{count} messages loaded into queue {output_queue}")
 
 
 @main.command()

--- a/submitter/message.py
+++ b/submitter/message.py
@@ -44,3 +44,46 @@ def body_from_json(message_json):
         }
         body["Files"].append({k: v for k, v in bitstream_data.items() if v is not None})
     return body
+
+
+def generate_result_messages_from_file(filepath, output_queue):
+    with open(filepath) as file:
+        messages = json.load(file)
+
+    for message_name, message_json in messages.items():
+        attributes = result_attributes_from_json(message_json)
+        body = result_body_from_json(message_json)
+        yield attributes, body
+
+
+def result_attributes_from_json(message_json):
+    attributes = {
+        "PackageID": {
+            "DataType": "String",
+            "StringValue": message_json["package id"],
+        },
+        "SubmissionSource": {
+            "DataType": "String",
+            "StringValue": message_json["source"],
+        },
+    }
+    return attributes
+
+
+def result_body_from_json(message_json):
+    body = {
+        "ResultType": message_json["result"],
+        "ItemHandle": message_json["handle"],
+        "lastModified": message_json["modified"],
+        "Bitstreams": [],
+    }
+    for file_json in message_json["files"]:
+        bitstream_data = {
+            "BitstreamName": file_json.get("bitstream name"),
+            "BitstreamUUID": file_json.get("uuid"),
+            "BitstreamChecksum": file_json.get("checksum"),
+        }
+        body["Bitstreams"].append(
+            {k: v for k, v in bitstream_data.items() if v is not None}
+        )
+    return body

--- a/tests/fixtures/completely-fake-data.json
+++ b/tests/fixtures/completely-fake-data.json
@@ -5,23 +5,41 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
-        {
-          "name": "file 1",
-          "location": "s3:/fakeloc2/f.json"
+      {
+        "name": "file 1",
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
         }
-      ]
-    },
+      }
+    ]
+  },
   "message 2": {
     "package id": "466",
     "source": "ETD",
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -31,10 +49,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -44,10 +71,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -57,10 +93,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -70,10 +115,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -83,10 +137,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -96,10 +159,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -109,10 +181,19 @@
     "target system": "DSpace@MIT",
     "collection handle": "1721.1/131022",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   },
@@ -122,10 +203,19 @@
     "target system": "devnull",
     "collection handle": "whatever",
     "metadata location": "s3:/fakeloc/a.json",
+    "result": "success",
+    "handle": "123456/67890",
+    "modified": "Thu Sep 09 17: 56: 39 UTC 2021",
     "files": [
       {
         "name": "file 1",
-        "location": "s3:/fakeloc2/f.json"
+        "location": "s3:/fakeloc2/f.json",
+        "bitstream name": "f.json",
+        "uuid": "abcdefg",
+        "checksum": {
+          "value": "2800ec8c99c60f5b15520beac9939a46",
+          "checkSumAlgorithm": "MD5"
+        }
       }
     ]
   }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from submitter.cli import main
 
 
-def test_cli_load_sample_data(mocked_sqs):
+def test_cli_load_sample_input_data(mocked_sqs):
     queue = mocked_sqs.get_queue_by_name(QueueName="empty_input_queue")
 
     sqs_messages = queue.receive_messages()
@@ -13,9 +13,30 @@ def test_cli_load_sample_data(mocked_sqs):
     result = runner.invoke(
         main,
         [
-            "load-sample-data",
+            "load-sample-input-data",
             "--input-queue",
             "empty_input_queue",
+            "--output-queue",
+            "empty_result_queue",
+        ],
+    )
+    assert result.exit_code == 0
+
+    sqs_messages = queue.receive_messages()
+    assert len(sqs_messages) > 0
+
+
+def test_cli_load_sample_output_data(mocked_sqs):
+    queue = mocked_sqs.get_queue_by_name(QueueName="empty_result_queue")
+
+    sqs_messages = queue.receive_messages()
+    assert len(sqs_messages) == 0
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "load-sample-output-data",
             "--output-queue",
             "empty_result_queue",
         ],

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,7 +1,7 @@
 from submitter import message
 
 
-def test_generate_messages_from_file():
+def test_generate_submission_messages_from_file():
     messages = message.generate_submission_messages_from_file(
         "tests/fixtures/completely-fake-data.json", "empty_output_queue"
     )
@@ -18,6 +18,33 @@ def test_generate_messages_from_file():
             "Files": [
                 {"BitstreamName": "file 1", "FileLocation": "s3:/fakeloc2/f.json"},
             ],
+        },
+    )
+
+
+def test_generate_result_messages_from_file():
+    messages = message.generate_result_messages_from_file(
+        "tests/fixtures/completely-fake-data.json", "empty_output_queue"
+    )
+    assert next(messages) == (
+        {
+            "PackageID": {"DataType": "String", "StringValue": "123"},
+            "SubmissionSource": {"DataType": "String", "StringValue": "ETD"},
+        },
+        {
+            "Bitstreams": [
+                {
+                    "BitstreamChecksum": {
+                        "checkSumAlgorithm": "MD5",
+                        "value": "2800ec8c99c60f5b15520beac9939a46",
+                    },
+                    "BitstreamName": "f.json",
+                    "BitstreamUUID": "abcdefg",
+                }
+            ],
+            "ItemHandle": "123456/67890",
+            "ResultType": "success",
+            "lastModified": "Thu Sep 09 17: 56: 39 UTC 2021",
         },
     )
 


### PR DESCRIPTION
Why are these changes being introduced:

* this allows an easier way to load sample messages to the result queue
  which is useful for testing consuming applications (such as ETD)

How does this address that need:

* Updates the existing sample json to include metadata useful for
  result messages
* Adds a CLI command and relevant methods to Messages to load the result
  sample data

#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)

#### How can a reviewer manually see the effects of these changes?

With .env configured to a valid result queue, run the new command and note the messages are created
in the result queue. Consuming those messages in a compliant app should behave as expected (note that the
sample data is not directly useful for any app without that app being put into a state that matches this output
which is out of scope of this ticket)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
