### PR TITLE
Add prod Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ run-stage:  ## Runs the task in stage - see readme for more info
 verify-dspace-connection-stage: # Verify stage app can connect to DSpace
 	aws ecs run-task --cluster DSS-SubmissionService-stage --task-definition DSS-SubmissionService-stage-task --network-configuration "awsvpcConfiguration={subnets=[subnet-05df31ac28dd1a4b0,subnet-04cfa272d4f41dc8a],securityGroups=[sg-0f64d9a1101d544d1],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1 --overrides '{"containerOverrides": [ {"name": "DSS", "command": ["verify-dspace-connection"]}]}'
 
+run-prod:  ## Runs the task in prod - see readme for more info
+	aws ecs run-task --cluster DSS-SubmissionService-prod --task-definition DSS-SubmissionService-prod-task --network-configuration "awsvpcConfiguration={subnets=[subnet-042726f373a7c5a79,subnet-05ab0e5c2bfcd748f],securityGroups=[sg-0325d8c490a870a90],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1
+
+verify-dspace-connection-prod: # Verify prod app can connect to DSpace
+	aws ecs run-task --cluster DSS-SubmissionService-prod --task-definition DSS-SubmissionService-prod-task --network-configuration "awsvpcConfiguration={subnets=[subnet-042726f373a7c5a79,subnet-05ab0e5c2bfcd748f],securityGroups=[sg-0325d8c490a870a90],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1 --overrides '{"containerOverrides": [ {"name": "DSS", "command": ["verify-dspace-connection"]}]}'
+
 # run-prod: ## Runs the task in stage - see readme for more info
 #   Not yet deployed in production
 


### PR DESCRIPTION
#### Includes new or updated dependencies?
NO

#### Changes expectations for external applications?
NO

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)

#### How can a reviewer manually see the effects of these changes?
`make verify-dspace-connection-prod` can be safely tested with the `dssManagement` policy.

**NOTE** The `Prod-Workloads` instance of DSS is now active and running `make run-prod` will process any messages in the `dss-input-prod` SQS queue and update our production DSpace instance.

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
