### PR TITLE
IN 1035 - log unhandled exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .DS_Store
 cov_html
 .vscode/
+.idea/

--- a/submitter/submission.py
+++ b/submitter/submission.py
@@ -188,7 +188,7 @@ class Submission:
             self.result_error_message(e.message, getattr(e, "dspace_error", None))
             clean_up_partial_success(client, item)
         except Exception as e:
-            logger.error(
+            logger.exception(
                 "Unexpected exception, aborting DSpace Submission Service processing"
             )
             raise e


### PR DESCRIPTION
### Purpose and background context

A [recent Sentry event](https://mit-libraries.sentry.io/issues/5713467790/?alert_rule_id=9963857&alert_type=issue&notification_uuid=4de7%5B%E2%80%A6%5D-b68f-539cf26aa88b&project=6068837&referrer=slack) indicates that an unhandled exception was encountered during `Submission.submit()`, but does not provide any details about the _underlying_ exception encountered.

The error handling in `submit()` is pretty intricate, where sub-methods called will handle exceptions and raise custom exceptions like `ItemCreateError`, `ItemPostError`, etc.  When these are encountered, there is logic in place to handle them.

But when an exception occurs that is not gracefully handled by this method, formerly only the following message was logged, but without any traceback or information about the _actual_ exception encountered:
> "Unexpected exception, aborting DSpace Submission Service processing"

This PR changes this from `logger.error` to `logger.exception` which will _also_ log the associated, underlying exception to Cloudwatch and Sentry.  In this way, we can understand what happened in this situation.

As noted in the [associated Jira ticket](https://mitlibraries.atlassian.net/browse/IN-1035), this is in support of some future work to better rollback any operations performed in Dspace and/or manage SQS queues.  Work will continue for this, but this intermediate PR at least begins to log unhandled exceptions in a way that supports retroactive debugging and understanding.

### How can a reviewer manually see the effects of these changes?

The newly created test `test_submit_dspace_unknown_api_error_logs_exception_and_raises_error` demonstrates this behavior.

Instead of a request to DSpace returning an HTTP response that _itself_ indicates any errors, the request to collection handle `"0000/collection04"` is mocked to throw a `requests.exceptions.RequestException` immediately.  Because there is not response, there is nothing to parse and report.

This test demonstrates that while we still don't have entirely graceful handling of unhandled exceptions during `Submission.submit()` (e.g. managing the SQS queue depending on what happened), we at least have logged the actual, underlying exception in a way that allows us to better react to the error.

### Includes new or updated dependencies?

NO

### Changes expectations for external applications?

NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1035

### Developer

- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
