### PR TITLE
Support Dspace item updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
         types: ["python"]
       - id: pip-audit
         name: pip-audit
-        entry: uv run pip-audit --ignore-vuln GHSA-rf74-v2fm-23pw --ignore-vuln CVE-2026-33230 --ignore-vuln CVE-2026-33231
+        entry: uv run pip-audit --ignore-vuln CVE-2026-4539
         language: system
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ ruff: # Run 'ruff' linter and print a preview of errors
 	uv run ruff check .
 
 safety: # Check for security vulnerabilities
-	uv run pip-audit --ignore-vuln GHSA-rf74-v2fm-23pw --ignore-vuln CVE-2026-33230 --ignore-vuln CVE-2026-33231
+	uv run pip-audit --ignore-vuln CVE-2026-4539
 
 lint-apply: black-apply ruff-apply # Apply changes with 'black' and resolve 'fixable errors' with 'ruff'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "click",
     "dspace-python-client",
     "dspace-rest-client>=0.1.16",
+    "jsonschema",
     "sentry-sdk",
     "smart-open",
 ]

--- a/submitter/errors.py
+++ b/submitter/errors.py
@@ -297,3 +297,12 @@ class SubmitMessageMissingAttributeError(Exception):
             f"'{CONFIG.input_queue}'. Message was missing required attribute "
             f"'{attribute_name}'."
         )
+
+
+# Submission message validation errors
+class SubmissionMessageAttributesValidationError(Exception):
+    """Exception raised due when submission message attributes are invalid"""
+
+
+class SubmissionMessageBodyValidationError(Exception):
+    """Exception raised due when submission message body is invalid"""

--- a/submitter/errors.py
+++ b/submitter/errors.py
@@ -117,20 +117,6 @@ class ItemPostError(Exception):  # Update after DSpace 8 migration
         self.dspace_error = source_error.response.text if source_error.response else None
 
 
-class BitstreamAddError(Exception):  # Update after DSpace 8 migration
-    """Exception raised when adding bitstream objects to an item instance.
-
-    Attributes:
-        message (str): Explanation of the error
-    """
-
-    def __init__(self) -> None:
-        self.message = (
-            "Error occurred while parsing bitstream information from files listed in "
-            "submission message."
-        )
-
-
 class BitstreamOpenError(Exception):  # Update after DSpace 8 migration
     """Exception raised when opening a file to post as a bitstream to DSpace.
 
@@ -255,47 +241,6 @@ class SQSMessageSendError(Exception):
             "queue and may need to be manually deleted before processing "
             f"resumes. Submit message ID: {submit_message_id}. Result message "
             f"attributes: {message_attributes}. Result message body: {message_body}"
-        )
-
-
-class SubmitMessageInvalidResultQueueError(Exception):
-    """Exception raised due to an invalid result queue name in a submission message.
-
-    Args:
-        message_id: The SQS message ID of the message causing the error
-        result_queue: The provided result queue name that caused the error
-
-    Attributes:
-        message(str): Explanation of the error
-    """
-
-    def __init__(self, message_id: str, result_queue: str | None):
-        self.message = (
-            "Aborting DSS processing due to a non-recoverable error:\nError occurred "
-            f"while processing message '{message_id}' from input queue "
-            f"'{CONFIG.input_queue}'. Message provided invalid result queue name "
-            f"'{result_queue}'. Valid result queue names are: "
-            f"{CONFIG.output_queues}."
-        )
-
-
-class SubmitMessageMissingAttributeError(Exception):
-    """Exception raised due to a missing required attribute in a submission message.
-
-    Args:
-        message_id: The SQS message ID of the message causing the error
-        attribute_name: The name of the attribute missing from the message
-
-    Attributes:
-        message(str): Explanation of the error
-    """
-
-    def __init__(self, message_id: str, attribute_name: str):
-        self.message = (
-            "Aborting DSS processing due to a non-recoverable error:\nError occurred "
-            f"while processing message '{message_id}' from input queue "
-            f"'{CONFIG.input_queue}'. Message was missing required attribute "
-            f"'{attribute_name}'."
         )
 
 

--- a/submitter/message.py
+++ b/submitter/message.py
@@ -1,5 +1,74 @@
 import json
+import logging
 from collections.abc import Iterator
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+import jsonschema
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs.service_resource import Message
+
+from submitter import errors
+from submitter.config import Config
+
+logger = logging.getLogger(__name__)
+CONFIG = Config()
+
+
+@lru_cache
+def load_jsonschemas() -> dict:
+    """Load SQS message attributes and body JSON Schema docs."""
+    logger.debug("Loading JSON schemas to cache")
+
+    # load SQS message attributes validation schema
+    with open("submitter/schemas/submission-message-attributes.json") as file:
+        attributes_schema = json.load(file)
+        # set constraint on "OutputQueue" using CONFIG
+        attributes_schema["properties"]["OutputQueue"]["properties"]["StringValue"][
+            "enum"
+        ] = CONFIG.output_queues
+
+    # load SQS message body validation schema
+    with open("submitter/schemas/submission-message-body.json") as file:
+        body_schema = json.load(file)
+
+    return {
+        "submission-message-attributes": attributes_schema,
+        "submission-message-body": body_schema,
+    }
+
+
+def validate_message(message: "Message") -> tuple[dict, dict]:
+    schemas = load_jsonschemas()
+
+    # validate message attributes
+    try:
+        jsonschema.validate(
+            instance=message.message_attributes,
+            schema=schemas["submission-message-attributes"],
+        )
+    except jsonschema.ValidationError as exception:
+        raise errors.SubmissionMessageAttributesValidationError(
+            exception.message
+        ) from exception
+
+    # parse and validate message body JSON string
+    try:
+        body = json.loads(message.body)
+        jsonschema.validate(instance=body, schema=schemas["submission-message-body"])
+    except json.JSONDecodeError as exception:
+        error_message = (
+            "Unable to parse submission message body. Message "
+            f"body provided was: '{message.body}'"
+        )
+        raise errors.SubmissionMessageBodyValidationError(error_message) from exception
+    except jsonschema.ValidationError as exception:
+        raise errors.SubmissionMessageBodyValidationError(
+            exception.message
+        ) from exception
+
+    return message.message_attributes, body
 
 
 def generate_submission_messages_from_file(

--- a/submitter/schemas/submission-message-attributes.json
+++ b/submitter/schemas/submission-message-attributes.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "DSS Submission Message Attributes Specification",
+    "description": "Schema to validate submission message attributes",
+    "type": "object",
+    "properties": {
+        "PackageID": {
+            "type": "object",
+            "properties": {
+                "DataType": {
+                    "const": "String"
+                },
+                "StringValue": {
+                    "description": "A unique ID created by the submitting application that will allow said application to match the result information to each submitted package, e.g. 'etd_123123' or '98765'. This system is agnostic about the value of the ID.",
+                    "type": "string"
+                }
+            }
+        },
+        "SubmissionSource": {
+            "type": "object",
+            "properties": {
+                "DataType": {
+                    "const": "String"
+                },
+                "StringValue": {
+                    "description": "Name of the submitting system, e.g. 'ETD'. Should be consistent for each submitting system (should not change over time",
+                    "type": "string"
+                }
+            }
+        },
+        "OutputQueue": {
+            "type": "object",
+            "properties": {
+                "DataType": {
+                    "const": "String"
+                },
+                "StringValue": {
+                    "description": "Name of the pre-agreed upon output SQS queue to be used for the submitting system. The queue must already exist and both systems must have appropriate access to the queue.",
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "required": [
+        "PackageID",
+        "SubmissionSource",
+        "OutputQueue"
+    ]
+}

--- a/submitter/schemas/submission-message-body.json
+++ b/submitter/schemas/submission-message-body.json
@@ -1,0 +1,86 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "DSS Submission Message Body Specification",
+    "description": "Schema to validate submission message body",
+    "type": "object",
+    "properties": {
+        "SubmissionSystem": {
+            "description": "Specific system to submit to",
+            "type": "string"
+        },
+        "Operation": {
+            "description": "Action to perform: create a new item or update an existing one",
+            "type": "string",
+            "default": "create",
+            "enum": [
+                "create",
+                "update"
+            ]
+        },
+        "CollectionHandle": {
+            "description": "Handle for DSpace Collection for created items",
+            "type": "string"
+        },
+        "ItemHandle": {
+            "description": "Handle for DSpace Item to be updated",
+            "type": "string"
+        },
+        "MetadataLocation": {
+            "description": "S3 URI for item metadata JSON file",
+            "type": "string"
+        },
+        "Files": {
+            "description": "Bitstreams for an item",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "BitstreamName": {
+                        "description": "Required - name of Bitstream in DSpace, e.g. 'baker_report.pdf'",
+                        "type": "string"
+                    },
+                    "FileLocation": {
+                        "description": "Required - S3 URI for Bitstream file , e.g. 'S3://bucket/baker_report.pdf'",
+                        "type": "string"
+                    },
+                    "BitstreamDescription": {
+                        "description": "Optional - description of Bitstream in DSpace, e.g. 'The Baker Report'",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "required": [
+                    "BitstreamName",
+                    "FileLocation"
+                ]
+            }
+        }
+    },
+    "required": [
+        "SubmissionSystem",
+        "MetadataLocation",
+        "Files"
+    ],
+    "if": {
+        "properties": {
+            "Operation": {
+                "const": "update"
+            }
+        },
+        "required": [
+            "Operation"
+        ]
+    },
+    "then": {
+        "required": [
+            "ItemHandle"
+        ]
+    },
+    "else": {
+        "required": [
+            "CollectionHandle"
+        ]
+    }
+}

--- a/submitter/submission.py
+++ b/submitter/submission.py
@@ -6,7 +6,8 @@ import sys
 import traceback
 from collections.abc import Iterator
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from enum import StrEnum
+from typing import TYPE_CHECKING, Literal
 
 import dspace
 import requests
@@ -25,6 +26,7 @@ from dspace_rest_client.models import Item as DSpace8Item
 
 from submitter import errors
 from submitter.config import Config
+from submitter.message import validate_message
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import Message
@@ -38,8 +40,12 @@ dspace_clients: dict[str, DSpace6Client | DSpace8Client] = (
 )  # Update after DSpace 8 migration
 
 
-class Submission:
+class ValidItemOperations(StrEnum):
+    CREATE = "create"
+    UPDATE = "update"
 
+
+class Submission:
     def __init__(
         self,
         attributes: dict,
@@ -47,12 +53,18 @@ class Submission:
         *,
         result_message: dict | str | None = None,
         destination: str | None = None,
+        operation: (
+            Literal[ValidItemOperations.CREATE, ValidItemOperations.UPDATE] | None
+        ) = ValidItemOperations.CREATE,
         collection_handle: str | None = None,
+        item_handle: str | None = None,
         metadata_location: str | None = None,
         files: list[dict] | None = None,
     ) -> None:
         self.destination = destination
+        self.operation = operation
         self.collection_handle = collection_handle
+        self.item_handle = item_handle
         self.metadata_location = metadata_location
         self.files = files
         self.result_attributes = attributes
@@ -185,51 +197,40 @@ class Submission:
             message: An SQS message
 
         Raises:
-            SubmitMessageInvalidResultQueueError
-            SubmitMessageMissingAttributeError
+            SubmissionMessageAttributesValidationError
+            SubmissionMessageBodyValidationError
         """
-        result_queue = message.message_attributes.get(  # type: ignore[call-overload]
-            "OutputQueue", {}
-        ).get("StringValue")
-        if not result_queue or result_queue not in CONFIG.output_queues:
-            raise errors.SubmitMessageInvalidResultQueueError(
-                message.message_id, result_queue
-            )
-
         try:
-            attributes = {
-                "PackageID": message.message_attributes["PackageID"],
-                "SubmissionSource": message.message_attributes["SubmissionSource"],
-            }
-        except KeyError as e:
-            raise errors.SubmitMessageMissingAttributeError(
-                message.message_id, e.args[0]
-            ) from e
-
-        try:
-            body = json.loads(message.body)
-            destination = body["SubmissionSystem"]
-            collection_handle = body["CollectionHandle"]
-            metadata_location = body["MetadataLocation"]
-            files = body["Files"]
-        except (json.JSONDecodeError, KeyError, TypeError):
-            result_message = (
-                "Submission message did not conform to the DSS specification. Message "
-                f"body provided was: '{message.body}'"
-            )
+            message_attributes, message_body = validate_message(message)
+        except errors.SubmissionMessageBodyValidationError as exception:
+            result_queue = message.message_attributes.pop("OutputQueue")["StringValue"]
             return cls(
-                attributes,
-                result_queue,
-                result_message=result_message,
+                attributes=message.message_attributes,
+                result_queue=result_queue,
+                result_message=str(exception),
             )
 
+        result_queue = message_attributes.pop("OutputQueue")["StringValue"]
+        operation = message_body.get("Operation", ValidItemOperations.CREATE)
+
+        if operation == ValidItemOperations.UPDATE:
+            return cls(
+                attributes=message_attributes,
+                result_queue=result_queue,
+                destination=message_body["SubmissionSystem"],
+                operation=operation,
+                item_handle=message_body["ItemHandle"],
+                metadata_location=message_body["MetadataLocation"],
+                files=message_body["Files"],
+            )
         return cls(
-            attributes,
-            result_queue,
-            destination=destination,
-            collection_handle=collection_handle,
-            metadata_location=metadata_location,
-            files=files,
+            attributes=message_attributes,
+            result_queue=result_queue,
+            destination=message_body["SubmissionSystem"],
+            operation=operation,
+            collection_handle=message_body["CollectionHandle"],
+            metadata_location=message_body["MetadataLocation"],
+            files=message_body["Files"],
         )
 
     def _submit_item_dspace6(  # Update after DSpace 8 migration

--- a/submitter/submission.py
+++ b/submitter/submission.py
@@ -106,7 +106,6 @@ class Submission:
         except (
             errors.SubmissionError,
             errors.ItemPostError,  # Update after DSpace 8 migration
-            errors.BitstreamAddError,  # Update after DSpace 8 migration
             errors.BitstreamOpenError,  # Update after DSpace 8 migration
             errors.BitstreamPostError,  # Update after DSpace 8 migration
         ) as e:
@@ -269,16 +268,14 @@ class Submission:
     ) -> DSpace6Item:
         """Add bitstreams to item from files in submission message."""
         logger.debug("Adding bitstreams to local item instance from submission message")
-        try:
-            for file in self.files or []:
-                bitstream = dspace.bitstream.Bitstream(
-                    file_path=file["FileLocation"],
-                    name=file["BitstreamName"],
-                    description=file.get("BitstreamDescription"),
-                )
-                item.bitstreams.append(bitstream)
-        except KeyError as e:
-            raise errors.BitstreamAddError from e
+
+        for file in self.files or []:
+            bitstream = dspace.bitstream.Bitstream(
+                file_path=file["FileLocation"],
+                name=file["BitstreamName"],
+                description=file.get("BitstreamDescription"),
+            )
+            item.bitstreams.append(bitstream)
         return item
 
     def _post_item_dspace6(  # Update after DSpace 8 migration

--- a/submitter/submission.py
+++ b/submitter/submission.py
@@ -19,6 +19,7 @@ from dspace.item import Item as DSpace6Item  # Update after DSpace 8 migration
 from dspace_rest_client.client import (
     DSpaceClient as DSpace8Client,
 )  # Update after DSpace 8 migration
+from dspace_rest_client.models import Bitstream as DSpace8Bitstream
 from dspace_rest_client.models import (
     Bundle as DSpace8Bundle,
 )  # Update after DSpace 8 migration
@@ -189,15 +190,23 @@ class Submission:
 
     @classmethod
     def from_message(cls, message: "Message") -> "Submission":
-        """
-        Create a submission with all necessary publishing data from a submit message.
+        """Create a submission with all required data from a submission message.
+
+        The SQS message is validated via two JSONSchema files, one for the message
+        attributes and one for the message body.  If the message ATTRIBUTES fail
+        validation, the job is killed immediately via the raised
+        errors.SubmissionMessageBodyValidationError exception.  This bubbles up to
+        the calling sqs.process() context because we cannot confidently remove the
+        item from the input queue, which is because we cannot send an
+        error result to the output queue.  By contrast, if only the message BODY
+        fails validation, an error result is sent to the output queue,
+        and the overall job continues.
 
         Args:
             message: An SQS message
 
         Raises:
             SubmissionMessageAttributesValidationError
-            SubmissionMessageBodyValidationError
         """
         try:
             message_attributes, message_body = validate_message(message)
@@ -327,11 +336,23 @@ class Submission:
                 ) from e
 
     def _submit_item_dspace8(self) -> tuple[DSpace8Item, DSpace8Bundle]:
-        """Submit item instance from submission message."""
-        item = self._create_item_dspace8()
-        bundle = self._create_bundle_dspace8(item)
-        for bitstream_uri in self.files or []:
-            self._create_bitstream_dspace8(item, bundle, bitstream_uri)
+        """Submit item instance from submission message.
+
+        This method can handle either item 'create' or 'update' operations,
+        which is indicated by self.operation. While this method raises a
+        SubmissionError in the event of an invalid value for self.operation,
+        if Submission is instantiated using from_message(), any invalid values
+        would have been captured by JSON schema validation beforehand.
+        """
+        if self.operation == "update":
+            item, bundle = self._update_item_dspace8()
+        elif self.operation == "create":
+            item = self._create_item_dspace8()
+            bundle = self._create_bundle_dspace8(item)
+            for bitstream_uri in self.files or []:
+                self._create_bitstream_dspace8(item, bundle, bitstream_uri)
+        else:
+            raise errors.SubmissionError(f"Operation not recognized: {self.operation}")
         return item, bundle
 
     def _create_item_dspace8(self) -> DSpace8Item:
@@ -458,6 +479,146 @@ class Submission:
             )
 
         logger.info(f"Bitstream created with UUID: {bitstream.uuid}")
+
+    def _update_item_dspace8(self) -> tuple[DSpace8Item, DSpace8Bundle]:
+        """Update item in DSpace"""
+        if not self.item_handle:
+            raise errors.ItemError(
+                "The 'item_handle' attribute must be a non-empty string"
+            )
+
+        item = self.client.resolve_identifier_to_dso(identifier=self.item_handle)
+        if not item:
+            raise errors.DSpaceObjectNotFoundError(self.item_handle)
+        item = DSpace8Item(dso=item)  # need to cast to DSpace 8 item
+
+        logger.debug(
+            "At this time, the 'update' operation only updates bitstreams "
+            "and adding metadata fields related to bitstream update!"
+        )
+        bundle = self._update_bitstream_dspace8(item)
+        return item, bundle
+
+    def _update_bitstream_dspace8(self, item: DSpace8Item) -> DSpace8Bundle:
+        """Update bitstreams for an item in DSpace.
+
+        This method updates the 'ORIGINAL' bundle for an item, which is
+        understood to be the container for its bitstreams. This method will
+        retrieve the 'ORIGINAL' bundle, delete existing bitstreams, and
+        create new bitstreams from the 'Files' provided in the submission
+        message body. This results in a full replacement of the item's bitstreams.
+
+        NOTE: At this time, DSS will only update items with a single bitstream
+        in their 'ORIGINAL' bundle.
+        """
+        if not self.files:
+            raise errors.ItemError("The 'files' attribute cannot be empty")
+
+        # get update date and timestamp
+        time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # track bitstreams deleted and added to Item
+        deleted_bitstreams = []
+        added_bitstreams = []
+
+        # messages for dc.description.provenance
+        update_messages = []
+
+        bundle = self._get_original_bundle(item)
+        if not bundle:
+            raise errors.ItemError(
+                f"Item {item.handle} does not have an 'ORIGINAL' bundle"
+            )
+
+        bitstreams = self.client.get_bitstreams(bundle=bundle)
+        if len(bitstreams) == 0 or len(bitstreams) > 1:
+            raise errors.ItemError(
+                f"Error occurred while updating item '{item.handle}, 'ORIGINAL' "
+                f"bundle {bundle.uuid} contains {len(bitstreams)} bitstream(s)"
+            )
+
+        original_bitstream = bitstreams[0]  # retrieve single bitstream
+        self._delete_bitstream_dspace8(original_bitstream)
+        deleted_bitstreams.append(original_bitstream.name)
+
+        # note deleted bitstreams
+        update_messages.append(
+            "Full replacement of bitstreams for bundle 'ORIGINAL'."
+            f"The following bitstreams were removed: {deleted_bitstreams}."
+        )
+
+        # update 'ORIGINAL' bundle with new bitstreams
+        for bitstream_uri in self.files:
+            # create bitstream
+            try:
+                bitstream = self.client.create_bitstream(
+                    bundle=bundle,
+                    name=os.path.basename(bitstream_uri["BitstreamName"]),
+                    path=bitstream_uri["FileLocation"],
+                )
+            except Exception as e:
+                logger.exception("Error creating bitstream:")
+                raise errors.BitstreamError(
+                    message=(
+                        "Error occurred while creating bitstream from file "
+                        f"'{bitstream_uri["BitstreamName"]}' for item '{item.handle}'"
+                    ),
+                    exception=e,
+                ) from e
+            added_bitstreams.append(bitstream.name)
+
+        # note added bitstreams
+        update_messages.append(
+            f"The following bitstreams were added: {added_bitstreams}."
+        )
+
+        # add dc.description.provenance for updated bitstreams
+        update_messages.append(f"Updated on {time}")
+        self.client.add_metadata(
+            item, field="dc.description.provenance", value=" ".join(update_messages)
+        )
+        return bundle
+
+    def _get_original_bundle(self, item: DSpace8Item) -> DSpace8Bundle | None:
+        for bundle in self.client.get_bundles_iter(parent=item):
+            if bundle.name == "ORIGINAL":
+                return bundle
+        return None
+
+    def _delete_bitstream_dspace8(self, bitstream: DSpace8Bitstream) -> None:
+        """Delete Bitstream object.
+
+        # NOTE: This code was pulled from dspace-rest-python's (v0.1.17)
+        # client.delete_dso method, which only supports deletion of SimpleDSpaceObject's,
+        # which does not include the Bitstream object. This is a temporary workaround
+        # until the client is updated or we find an alternative way to send requests
+        # to DSpace REST API.
+        """
+        try:
+            bitstream_url = bitstream.links["self"]["href"]
+            response = self.client.api_delete(url=bitstream_url, params=None)
+        except ValueError as e:
+            raise errors.BitstreamError(
+                message=(f"Error occurred while deleting bitstream {bitstream.uuid}"),
+                exception=e,
+            ) from e
+
+        # TODO: This check is added to raise an exception if
+        # response.status_code is not equal to 204 (No Content).
+        # Should be updated if/when dspace-rest-python is
+        # updated to raise exceptions.
+        if response.status_code == 204:  # noqa: PLR2004
+            logger.info(
+                f"Bitstream '{bitstream.name}' (uuid={bitstream.uuid}) "
+                "deleted from DSpace"
+            )
+        else:
+            raise errors.BitstreamError(
+                message=(
+                    f"Error occurred while deleting bitstream {bitstream.uuid}: "
+                    f"{response.status_code} {response.text}"
+                )
+            )
 
     def result_error_message(
         self, message: str, dspace_response: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,7 +340,29 @@ def input_message_good_dspace8(mocked_sqs):
 
 
 @pytest.fixture
-def input_message_nonconforming_body(mocked_sqs):
+def input_message_missing_collection_handle(mocked_sqs):
+    queue = mocked_sqs.get_queue_by_name(QueueName="empty_input_queue")
+    queue.send_message(
+        MessageAttributes=test_attributes,
+        MessageBody=json.dumps(
+            {
+                "SubmissionSystem": "DSpace@MIT",
+                "MetadataLocation": "tests/fixtures/test-item-metadata.json",
+                "Files": [
+                    {
+                        "BitstreamName": "test-file-01.pdf",
+                        "FileLocation": "tests/fixtures/test-file-01.pdf",
+                        "BitstreamDescription": "A test bitstream",
+                    }
+                ],
+            }
+        ),
+    )
+    return queue.receive_messages(MessageAttributeNames=["All"])[0]
+
+
+@pytest.fixture
+def input_message_invalid_json(mocked_sqs):
     queue = mocked_sqs.get_queue_by_name(QueueName="empty_input_queue")
     queue.send_message(
         MessageAttributes=test_attributes,

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,4 +1,5 @@
 # ruff: noqa: SLF001
+import re
 import sys
 import traceback
 from unittest.mock import patch
@@ -106,27 +107,62 @@ def test_submission_from_message_dspace6_success(
     assert submission.result_queue == "empty_result_queue"
 
 
-def test_submission_from_message_dspace6_creates_error_message(
-    input_message_nonconforming_body, mocked_dspace
+def test_submission_from_message_dspace8_success(
+    input_message_good_dspace8, mocked_dspace
 ):
-    submission = Submission.from_message(input_message_nonconforming_body)
+    submission = Submission.from_message(input_message_good_dspace8)
+    assert submission.destination == "IR-8"
+    assert submission.collection_handle == "0000/collection01"
+    assert submission.metadata_location == "tests/fixtures/test-item-metadata.json"
+    assert submission.files == [
+        {
+            "BitstreamName": "test-file-01.pdf",
+            "FileLocation": "tests/fixtures/test-file-01.pdf",
+            "BitstreamDescription": "A test bitstream",
+        }
+    ]
+    assert submission.result_attributes == {
+        "PackageID": {"DataType": "String", "StringValue": "etdtest01"},
+        "SubmissionSource": {"DataType": "String", "StringValue": "etd"},
+    }
+    assert submission.result_message is None
+    assert submission.result_queue == "empty_result_queue"
+
+
+def test_submission_from_message_handles_message_body_jsondecodeerror(
+    input_message_invalid_json, mocked_dspace
+):
+    submission = Submission.from_message(input_message_invalid_json)
     assert submission.result_message == (
-        "Submission message did not conform to the DSS specification. Message body "
-        "provided was: 'Doesn't conform to the DSS spec'"
+        "Unable to parse submission message body. Message body provided was: "
+        "'Doesn't conform to the DSS spec'"
     )
 
 
-def test_submission_from_message_dspace6_raises_invalid_queue_error(
+def test_submission_from_message_handles_message_body_validationerror(
+    input_message_missing_collection_handle,
+):
+    submission = Submission.from_message(input_message_missing_collection_handle)
+    assert "'CollectionHandle' is a required property" in submission.result_message
+
+
+def test_submission_from_message_invalid_queue_raises_message_attr_validationerror(
     input_message_invalid_queue, mocked_dspace
 ):
-    with pytest.raises(errors.SubmitMessageInvalidResultQueueError):
+    with pytest.raises(
+        errors.SubmissionMessageAttributesValidationError,
+        match=re.escape("'not-a-queue' is not one of ['empty_result_queue']"),
+    ):
         Submission.from_message(input_message_invalid_queue)
 
 
-def test_submission_from_message_raises_missing_attribute_error(
+def test_submission_from_message_missing_required_raises_message_attr_validationerror(
     input_message_missing_attribute,
 ):
-    with pytest.raises(errors.SubmitMessageMissingAttributeError):
+    with pytest.raises(
+        errors.SubmissionMessageAttributesValidationError,
+        match=re.escape("'SubmissionSource' is a required property"),
+    ):
         Submission.from_message(input_message_missing_attribute)
 
 
@@ -279,13 +315,7 @@ def test_submit_dspace6_add_bitstreams_error(
 ):
     mock_dspace_client.return_value = test_dspace6_client
     submission = Submission.from_message(input_message_bitstream_create_error)
-    submission.submit()
-    assert submission.result_message["ResultType"] == "error"
-    assert (
-        submission.result_message["ErrorInfo"]
-        == "Error occurred while parsing bitstream information from files listed in "
-        "submission message."
-    )
+    assert submission.result_message == "'FileLocation' is a required property"
 
 
 @patch("submitter.submission.DSpace6Client")

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -129,7 +129,14 @@ def test_submission_from_message_dspace8_success(
     assert submission.result_queue == "empty_result_queue"
 
 
-def test_submission_from_message_handles_message_body_jsondecodeerror(
+def test_submission_from_message_defaults_to_create_operation(input_message_good_dspace8):
+    submission = Submission.from_message(input_message_good_dspace8)
+
+    assert "Operation" not in input_message_good_dspace8.body
+    assert submission.operation == "create"
+
+
+def test_submission_from_message_body_jsondecodeerror_handled(
     input_message_invalid_json, mocked_dspace
 ):
     submission = Submission.from_message(input_message_invalid_json)
@@ -139,14 +146,14 @@ def test_submission_from_message_handles_message_body_jsondecodeerror(
     )
 
 
-def test_submission_from_message_handles_message_body_validationerror(
+def test_submission_from_message_body_missing_required_property_is_handled(
     input_message_missing_collection_handle,
 ):
     submission = Submission.from_message(input_message_missing_collection_handle)
     assert "'CollectionHandle' is a required property" in submission.result_message
 
 
-def test_submission_from_message_invalid_queue_raises_message_attr_validationerror(
+def test_submission_from_message_attr_invalid_queue_raises_validationerror(
     input_message_invalid_queue, mocked_dspace
 ):
     with pytest.raises(
@@ -156,7 +163,7 @@ def test_submission_from_message_invalid_queue_raises_message_attr_validationerr
         Submission.from_message(input_message_invalid_queue)
 
 
-def test_submission_from_message_missing_required_raises_message_attr_validationerror(
+def test_submission_from_message_attr_missing_required_property_raises_validationerror(
     input_message_missing_attribute,
 ):
     with pytest.raises(

--- a/uv.lock
+++ b/uv.lock
@@ -34,15 +34,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -136,29 +136,29 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.71"
+version = "1.42.75"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/39/774ff22347856ebbe9da350045ad5851aa0524ee6e4832fdc98b27981801/boto3-1.42.71.tar.gz", hash = "sha256:500edd2699a3f479053bbfb407b06c231d1ff1e574f7c90d269d605a6a1f8160", size = 112773, upload-time = "2026-03-18T19:44:37.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/1c/f836f5e52095a3374eee9317f980a22d9139477fe6277498ebf4406e35b4/boto3-1.42.75.tar.gz", hash = "sha256:3c7fd95a50c69271bd7707b7eda07dcfddb30e961a392613010f7ee81d91acb3", size = 112812, upload-time = "2026-03-24T21:14:00.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/b6/b0b93090cfc3fdbdb21a0b18961508678a2b36a42e2b3a90994ac34e102c/boto3-1.42.71-py3-none-any.whl", hash = "sha256:a89fae01c4bc948671e99440ddc0f10bc73cc72d83218656057f730df0898eab", size = 140553, upload-time = "2026-03-18T19:44:35.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/c04caef287a0ea507ba634f2280dbe8314d89c1d8da1aef648b661ad1201/boto3-1.42.75-py3-none-any.whl", hash = "sha256:16bc657d16403ee8e11c8b6920c245629e37a36ea60352b919da566f82b4cb4c", size = 140556, upload-time = "2026-03-24T21:13:58.004Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.42.71"
+version = "1.42.75"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/0c/e0dee45b6f8fd1afd192ad0c68d9b03c2ddee99171d173cb4274df304623/boto3_stubs-1.42.71.tar.gz", hash = "sha256:7ece30dbfe719556e84d88872833d34e2ea81e8fa5dfbf581e6eec80fbf400e3", size = 101368, upload-time = "2026-03-18T19:54:12.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/63/3b1e82011adafa79217e38c1675acfc2138d476246ce9987cc16d1970479/boto3_stubs-1.42.75.tar.gz", hash = "sha256:0c5341b62ea713328bbc66e455cd95490b4c4478e474a5e2022aa43e7e1f798e", size = 101354, upload-time = "2026-03-24T21:54:15.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/fc/d488a1a1b8473a533c3962227385f4735a75a570baea0f31c3fd5f2d144d/boto3_stubs-1.42.71-py3-none-any.whl", hash = "sha256:6cc9f1e168abf42b66dd31a2d6abaf5b4ac898ea3e122aaba6caa570b416d641", size = 70011, upload-time = "2026-03-18T19:54:08.863Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5d/1467972bdfaec7fb12493e767f4109ac327323b6ddf75530b557da94eaf4/boto3_stubs-1.42.75-py3-none-any.whl", hash = "sha256:1872b3c0a43051a58ff9e5a782070cde28db67e24f3f41c2d6124166a11e821f", size = 70012, upload-time = "2026-03-24T21:54:08.695Z" },
 ]
 
 [package.optional-dependencies]
@@ -174,16 +174,16 @@ essential = [
 
 [[package]]
 name = "botocore"
-version = "1.42.71"
+version = "1.42.75"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/65/a76ced7e1c7f61880ec474e301cb63c27fd47c09ae0b7e4ccaa3cd3b04c6/botocore-1.42.71.tar.gz", hash = "sha256:6b3796c76edeb78afee325a54e23508bbd57624faea1e4aeb8f6e9c1e1e79a0f", size = 14998263, upload-time = "2026-03-18T19:44:25.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/05/b16d6ac5eea465d42e65941436eab7d2e6f6ebef01ba4d70b6f5d0b992ce/botocore-1.42.75.tar.gz", hash = "sha256:95c8e716b6be903ee1601531caa4f50217400aa877c18fe9a2c3047d2945d477", size = 15016308, upload-time = "2026-03-24T21:13:48.802Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/b3/b970b62963b2391d10cd29402d3338bf49730e083aa9b2a688c8bf76af08/botocore-1.42.71-py3-none-any.whl", hash = "sha256:e6b7c611eeacbfa6a5a08cd56889b7a63eced48e99f8db9b270eeaf2c0b62796", size = 14671820, upload-time = "2026-03-18T19:44:20.997Z" },
+    { url = "https://files.pythonhosted.org/packages/04/21/22148ff8d37d8706fc63cdc8ec292f4abbbd18b500d9970f6172f7f3bb30/botocore-1.42.75-py3-none-any.whl", hash = "sha256:915e43b7ac8f50cf3dbc937ba713de5acb999ea48ad8fecd1589d92ad415f787", size = 14689910, upload-time = "2026-03-24T21:13:43.939Z" },
 ]
 
 [[package]]
@@ -680,11 +680,11 @@ wheels = [
 
 [[package]]
 name = "jsonpointer"
-version = "3.0.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]
@@ -926,20 +926,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-dynamodb"
-version = "1.42.55"
+version = "1.42.73"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/e5/e68bf109e994cf1a2468c915606c20bf0ebb5b10ff0b82e63c7f7f102e8b/mypy_boto3_dynamodb-1.42.55.tar.gz", hash = "sha256:a445f439b6bc4532fd592cb7f44444c8fc8f397271c0d9087e712f71f196d2f9", size = 48685, upload-time = "2026-02-23T20:40:16.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/a2/fc93b44ed07322ede4cc45c6c66370ff53ad8a195b95f9f80d1edbb7735a/mypy_boto3_dynamodb-1.42.73.tar.gz", hash = "sha256:3fd9e093a8c982a53d55f6ac3d109d89957fe82b5c7ece65f27b772ed7a5ca9b", size = 48723, upload-time = "2026-03-20T19:59:32.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/ce/89a62cc767f4120c8601ab20a3942653370c50935bbd2628d33dc60d162e/mypy_boto3_dynamodb-1.42.55-py3-none-any.whl", hash = "sha256:652af33641601d223fb35207b89bd98513a7493d2b95ae4cba47c925b6ec103c", size = 58774, upload-time = "2026-02-23T20:35:18.462Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/f4ececbceb13d1c2fbc1cfee56d65231c98b19f4d0b41baf3ab5d88b6863/mypy_boto3_dynamodb-1.42.73-py3-none-any.whl", hash = "sha256:2df84f71ff41fba5f12e803be19c4483daa64ba030fc9d62ba5e5f9f09a4def8", size = 58828, upload-time = "2026-03-20T19:59:24.878Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ec2"
-version = "1.42.71"
+version = "1.42.72"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/15/b602ca5840d26d5ba8d7e5f73dc7d9f5d0858af8fd2420ee74131de63d1e/mypy_boto3_ec2-1.42.71.tar.gz", hash = "sha256:9e531887fb797466ec7cc1bf7a968881464ae407205c14d69852bc3cf469a60d", size = 441510, upload-time = "2026-03-18T19:54:02.329Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c5/0e2bb8810bdedd5efd89415a708fa31912f934c8b77ec3b448a50cb0f6f6/mypy_boto3_ec2-1.42.72.tar.gz", hash = "sha256:50f145404c6761334c5d4314d0ca233e558c6bc57a6831bdb5eeb2bb8eb81799", size = 441802, upload-time = "2026-03-19T21:30:23.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/57/b0145f193d0d5d00e7b48aa50f3d0147fa383b810386df5e65dd5fbf5f78/mypy_boto3_ec2-1.42.71-py3-none-any.whl", hash = "sha256:5b7b7df51731b59f716e52be1efb53d9fc8c9356c32d7b63d68cb57e1860ae12", size = 430825, upload-time = "2026-03-18T19:53:57.405Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/00/c7784c46ad1d5bede6a946cffd42ca7e07aa8608a029c1282483536eacbe/mypy_boto3_ec2-1.42.72-py3-none-any.whl", hash = "sha256:ed6d61171ae188ff90540fb326ef87925dc60eedc2f9e65b98d05a487b6c26f6", size = 431076, upload-time = "2026-03-19T21:30:19.294Z" },
 ]
 
 [[package]]
@@ -953,11 +953,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-rds"
-version = "1.42.51"
+version = "1.42.75"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/c3/f581402e1b7a39c4220599ccf2dba2fb91db57095a0d1c975fc49501fa57/mypy_boto3_rds-1.42.51.tar.gz", hash = "sha256:d09d0cf5070eb51ac8aedacb63594d689fe8c279a1c836dfbd06a714caac8bde", size = 86300, upload-time = "2026-02-17T21:34:40.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/aa/ce727ee352b7b49709bd77323c453b315c2f575d722d73e177e43a89bcb0/mypy_boto3_rds-1.42.75.tar.gz", hash = "sha256:319fba3ad1f529d3cfb4bc8d75a762ec9b3567f1379dca940a7a47e7a89c3876", size = 86525, upload-time = "2026-03-24T21:54:05.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/ce/5c8aab9e0853b29b766dc2b82e9a732d82b8e2217f0384830749dcc4067c/mypy_boto3_rds-1.42.51-py3-none-any.whl", hash = "sha256:a2e01011dc235e9ce250dbc6a71f106ace5a4830e37ebbd041b3321cac4905c1", size = 93033, upload-time = "2026-02-17T21:29:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ee/fa5e11354fab63ddb97bd33a072d704588cd894def53ecf73de8857ddca8/mypy_boto3_rds-1.42.75-py3-none-any.whl", hash = "sha256:360a0e0304b6f7bf7c3ce951bef6da3be20ed82c37806de93c82bfa780022351", size = 93206, upload-time = "2026-03-24T21:54:02.149Z" },
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.3"
+version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1006,9 +1006,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/8f/915e1c12df07c70ed779d18ab83d065718a926e70d3ea33eb0cd66ffb7c0/nltk-3.9.3.tar.gz", hash = "sha256:cb5945d6424a98d694c2b9a0264519fab4363711065a46aa0ae7a2195b92e71f", size = 2923673, upload-time = "2026-02-24T12:05:53.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/7e/9af5a710a1236e4772de8dfcc6af942a561327bb9f42b5b4a24d0cf100fd/nltk-3.9.3-py3-none-any.whl", hash = "sha256:60b3db6e9995b3dd976b1f0fa7dec22069b2677e759c28eb69b62ddd44870522", size = 1525385, upload-time = "2026-02-24T12:05:46.54Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -1322,16 +1322,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1471,9 +1471,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]
@@ -1561,27 +1561,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.6"
+version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
-    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]
@@ -1642,15 +1642,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.55.0"
+version = "2.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/b8/285293dc60fc198fffc3fcdbc7c6d4e646e0f74e61461c355d40faa64ceb/sentry_sdk-2.55.0.tar.gz", hash = "sha256:3774c4d8820720ca4101548131b9c162f4c9426eb7f4d24aca453012a7470f69", size = 424505, upload-time = "2026-03-17T14:15:51.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/df/5008954f5466085966468612a7d1638487596ee6d2fd7fb51783a85351bf/sentry_sdk-2.56.0.tar.gz", hash = "sha256:fdab72030b69625665b2eeb9738bdde748ad254e8073085a0ce95382678e8168", size = 426820, upload-time = "2026-03-24T09:56:36.575Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl", hash = "sha256:97026981cb15699394474a196b88503a393cbc58d182ece0d3abe12b9bd978d4", size = 449284, upload-time = "2026-03-17T14:15:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/1a/b3a3e9f6520493fed7997af4d2de7965d71549c62f994a8fd15f2ecd519e/sentry_sdk-2.56.0-py2.py3-none-any.whl", hash = "sha256:5afafb744ceb91d22f4cc650c6bd048ac6af5f7412dcc6c59305a2e36f4dbc02", size = 451568, upload-time = "2026-03-24T09:56:34.807Z" },
 ]
 
 [[package]]
@@ -1861,14 +1861,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.4.20260107"
+version = "2.32.4.20260324"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/b1/66bafdc85965e5aa3db42e1b9128bf8abe252edd7556d00a07ef437a3e0e/types_requests-2.32.4.20260324.tar.gz", hash = "sha256:33a2a9ccb1de7d4e4da36e347622c35418f6761269014cc32857acabd5df739e", size = 23765, upload-time = "2026-03-24T04:06:35.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/ce5999f9bd72c7fac681d26cd0a5782b379053bfc2214e2a3fbe30852c9e/types_requests-2.32.4.20260324-py3-none-any.whl", hash = "sha256:f83ef2deb284fe99a249b8b0b0a3e4b9809e01ff456063c4df0aac7670c07ab9", size = 20735, upload-time = "2026-03-24T04:06:33.9Z" },
 ]
 
 [[package]]
@@ -1927,14 +1927,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.6"
+version = "3.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", hash = "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351", size = 875700, upload-time = "2026-03-24T01:08:07.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", hash = "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f", size = 226295, upload-time = "2026-03-24T01:08:06.133Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1710,6 +1710,7 @@ dependencies = [
     { name = "click" },
     { name = "dspace-python-client" },
     { name = "dspace-rest-client" },
+    { name = "jsonschema" },
     { name = "sentry-sdk" },
     { name = "smart-open" },
 ]
@@ -1740,6 +1741,7 @@ requires-dist = [
     { name = "click" },
     { name = "dspace-python-client", git = "https://github.com/mitlibraries/dspace-python-client.git" },
     { name = "dspace-rest-client", specifier = ">=0.1.16" },
+    { name = "jsonschema" },
     { name = "sentry-sdk" },
     { name = "smart-open" },
 ]


### PR DESCRIPTION
### Purpose and background context

This PR includes changes to support updates to existing items in DSpace. It's worth noting that this first pass of item update support is oriented towards our first known use case: [the new workflow planned for digitized theses ](https://mitlibraries.atlassian.net/wiki/spaces/IN/pages/5130813443/Engineering+Plan+Implementing+the+Digitized+Theses+Workflow+with+DSO). An "item update" means:

1. `Bitstream`s for an item, which are assumed to be contained within the "ORIGINAL" `Bundle` for an `Item`, are deleted and replaced with the files indicated in the submission message.
2. The only change to metadata is the addition of a `dc.description.provenance` entry to indicate deleted and replaced bitstreams.

DataEng also agreed to set a guardrail for this first pass:
1. If the "ORIGINAL" `Bundle` for an item contains more than one (`>1`) bitstream, [raise an error (i.e., do not proceed with update)](https://github.com/MITLibraries/dspace-submission-service/blob/IN-1681-support-dspace-item-updates/submitter/submission.py#L512-L516)

While the focus of this work is implement item update support, this PR also introduces JSON schemas and the `jsonschema` module to validate submission messages. Prior to these changes, message validation was handled by a series of `if` statements in `Submission.from_message`, however, with the addition of the "update" operation and its own set of message requirements, continuing this approach proved difficult. Enter JSON schemas! JSON schemas are better suited for more complex validation of data structures (e.g., JSON-formatted submission messages). Here are some key things to point out:
* A new directory `submitter/schemas` was created
* There are two JSON schemas, one for message attributes (`submission-message-attributes.json`) and another for message body (`submission-message-body.json`).
* There are two new helper methods in `submitter.message`:
   * `load_jsonschemas`: Load JSON schemas to a cache
   * `validate_message`: Validate contents of SQS `Message` object.
* Several custom exceptions were deprecated as a result of JSON schemas now performing whatever validation check the deprecated exceptions were associated with. See https://github.com/MITLibraries/dspace-submission-service/pull/61/changes/a7617ced85c10812fc940dfe6d22711f91dec3ed commit message for details.

---

**Out of scope**
A key learning gathered from this work was that DSS jobs will immediately exit when something is wrong with the submission message (`Message.message_attributes`):
* Code previously [raises errors when message attributes fails a series of checks](https://github.com/MITLibraries/dspace-submission-service/blob/43449ce75cac8b46d7afe6f772d21d8f4c04ab9a/submitter/submission.py#L191-L207) and [the calling method (`submitter.sqs.process`) does not handle any raised exceptions](https://github.com/MITLibraries/dspace-submission-service/blob/43449ce75cac8b46d7afe6f772d21d8f4c04ab9a/submitter/sqs.py#L49-L51)

It's worth noting that this PR does not change this outcome; it only changes the custom exception that is raised (`SubmissionMessageAttributesValidationError`). @ghukill and I had some initial discussions on changes, but I'm opting to create a separate ticket for further discussion: https://mitlibraries.atlassian.net/browse/IN-1698

---

### How can a reviewer manually see the effects of these changes?

Given the noted issues with `dspace-rest-python` and the "in flux" state of DSS, I opted for minimal updates unit tests and instead focused on running the test cases shared below. 

These test cases effectively demonstrate that the updates to DSS to support item updates + are functional, without introducing any breaking changes. In addition, the use of JSON schemas to validate submission messages allow for more detailed validation error messages.

**Test runs**

Submission messages were manually constructed and sent via the AWS console (on SQS) with the following message attributes:
<img width="713" height="197" alt="image" src="https://github.com/user-attachments/assets/bca01125-6723-413d-840f-1c35d10360e3" />

1. Submission message for item **create** with valid message attributes and message body. No `Operation` provided, showing default to item creation.
   ```text
   {"SubmissionSystem": "IR-8", "CollectionHandle": "1721.1/164264", "MetadataLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/dspace_metadata/14.02-fall-2004_metadata.json", "Files": [{"BitstreamName": "14.02-fall-2004.zip", "FileLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/14.02-fall-2004.zip", "BitstreamDescription": null}]}
   ```
   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252F653879b9d28a45e09550626f8cde2a3b)
   4. See ingested item: https://mit-dspace.eks.prod.4science.cloud/handle/1721.1/164527

1. Submission message for item **create** with invalid message body (no `"CollectionHandle"`)
   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252F04bc229acbc54d4285124d318aaf8da4). Note this log:
      ```
      2026-03-24 21:16:36,733 DEBUG submitter.sqs.process() line 64: Wrote message to queue 'dss-output-dsc-dev' with message body: "'CollectionHandle' is a required property"
      ```
   1. Item not ingested, `SubmissionMessageBodyValidationError` captured and handled, submission message deleted, result message written.

1. Submission message for item **update** with valid message attributes and message body (updates ingested item from **1**)
   Message body:
   ```text
   {"SubmissionSystem": "IR-8", "Operation": "update", "ItemHandle": "1721.1/164527", "MetadataLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/dspace_metadata/14.02-fall-2004_metadata.json", "Files": [{"BitstreamName": "14.02-fall-2004.zip", "FileLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/14.02-fall-2004.zip", "BitstreamDescription": null}]}
   ```
   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252Ff9fc3001867d4ea68cb3babf709efa12). Note these logs:
   2. 
      ```text
      2026-03-25 13:04:01,100 WARNING submitter.submission._update_item_dspace8() line 478: At this time, the 'update' operation only updates bitstreams and adding metadata fields related to bitstream update!
      2026-03-25 13:04:01,198 INFO submitter.submission._delete_bitstream_dspace8() line 575: Bitstream '14.02-fall-2004.zip' (uuid=2f9caeb1-e498-453c-b661-a0332cbb017a) deleted from DSpace
      2026-03-25 13:04:03,043 INFO submitter.submission._create_bitstream_dspace8() line 464: Bitstream created with UUID: 1a752366-6623-441c-90f6-1b51a91667cb
      2026-03-25 13:04:03,497 INFO root.api_patch() line 451: successful patch update to item 3bcea67e-8ad3-422a-b3f0-ce060ed232f4
      ```

   1. See updated item ("Admin" view of record): https://mit-dspace.eks.prod.4science.cloud/items/3bcea67e-8ad3-422a-b3f0-ce060ed232f4/edit/metadata; note addition of `dc.description.provenance` metadata:
      <img width="892" height="261" alt="image" src="https://github.com/user-attachments/assets/8902baab-9400-4304-abaa-bd32cbf8897f" />



1. Submission message for item **update** with invalid message body (no `"ItemHandle"`)
   Message body:
   ```text
   {"SubmissionSystem": "IR-8", "Operation": "update", "MetadataLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/dspace_metadata/14.02-fall-2004_metadata.json", "Files": [{"BitstreamName": "14.02-fall-2004.zip", "FileLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/14.02-fall-2004.zip", "BitstreamDescription": null}]}
   ```
   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252Ff5699beea4034708b64aa9e444edd852). Note this log:
      ```text
      2026-03-24 21:41:59,202 DEBUG submitter.sqs.process() line 64: Wrote message to queue 'dss-output-dsc-dev' with message body: "'ItemHandle' is a required property"
      ```
   1.  Item not ingested, `SubmissionMessageBodyValidationError` captured and handled, submission message deleted, result message written.

1. Submission message for item **update** with invalid message body (cannot parse JSON)
   Message body: 
   ```text
   {"SubmissionSystem": "IR-8", "Operation": "update",  "ItemHandle": "1721.1/164527, "MetadataLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/dspace_metadata/14.02-fall-2004_metadata.json", "Files": [{"BitstreamName": "14.02-fall-2004.zip", "FileLocation": "s3://dsc-upload-dev-222053980223/opencourseware/2026-02-11-opencourseware-dss-test/14.02-fall-2004.zip", "BitstreamDescription": null}]}
   ```

   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252Fce1cb6eefcf3492ea774e78b64e85730)
   1. Item not ingested, `JSONDecodeError` captured as `SubmissionMessageBodyValidationError` and handled, submission message deleted, result message written.

1. Submission message for item with invalid message attribute (missing 'SubmissionSource')
   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252F1d2f5802dae44c069506d205f853e73f)
   1. 👉🏼 **IMPORTANT:** [`SubmissionMessageAttributesValidationError` is not handled (no `except` block for this exception)](https://github.com/MITLibraries/dspace-submission-service/blob/IN-1681-support-dspace-item-updates/submitter/submission.py#L203-L211)

1. Performed an **additional test to confirm JSON schemas are cached**
   1. See [CloudWatch log stream](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/dss-ecs-dev/log-events/dso$252Fdso-dss-dev$252F23fe547252f3480c99169dcd4ff50589). Note the log `Loading JSON schemas to cache` appears once though there are 2 submission messages to process.

### Includes new or updated dependencies?
YES - Adds `jsonschema` as dependency and ran `make update` to resolve previously failing CVEs. Need to ignore CVE-2026-4539 until fix available.

### Changes expectations for external applications?
NO - DSS will default to `create` operation and the new `Operation` field for the submission message body is optional. Any applications that plan on using the `update` operation, which should only be DSC (workflow for digitized theses) as of this writing, should note that updates require `Operation: "create"` and the `ItemHandle` in the submission message body. There is a separate ticket to update the DSS message specs documentation.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1681
- https://mitlibraries.atlassian.net/browse/IN-1682

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.
